### PR TITLE
Fix style for WMS Result data

### DIFF
--- a/lib/mv.js
+++ b/lib/mv.js
@@ -288,11 +288,15 @@ var mv = (function () {
                     }
                     div.push('>');
                     div.push(
-                            '<div class="checkbox">',
-                                '<label><input id="' + result.layerid + '-ck" type="checkbox" aria-label="..."><strong>' + result.extTitle + '</strong></label>',
-                            '</div>',
-                            '<small>' + _abstract + '</small>',
-                        '</div>');
+                        '<div class="checkbox list-group-item">',
+                        '<div class="custom-control custom-checkbox">',
+                            '<input type="checkbox" class="custom-control-input" id="' + result.layerid + '-ck">',
+                            '<label class="custom-control-label" for="' + result.layerid + '-ck">',
+                                '<span style="font-weight:600;">' + result.extTitle + '</span></br>',
+                                '<span>' + _abstract + '</span>',
+                            '</label>',
+                        '</div>',
+                    '</div>');
                     html.push(div.join(""));
                     nb_results ++;
                 }


### PR DESCRIPTION
A l'image des résultats CSW, harmonisation du style des données renvoyées par un catalogue WMS : 

![image](https://user-images.githubusercontent.com/22764056/218793003-e1c1b37d-9983-48d1-9b91-2427f11e3078.png)

Correction de l'issue #175