### PR TITLE
Corrections des bugs #157

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@2.2.0/fonts/remixicon.css">
     <link rel="stylesheet" href="lib/openlayers/7.1/ol.css" type="text/css">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.13.0/css/all.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
     <script src="lib/Sortable.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/4.6.3/papaparse.min.js"></script>
@@ -295,8 +295,8 @@
                                             <div class="list-flex">
                                                 <span i18n="tabs.app.opt_zoom">Outils de zoom</span>
                                                 <div class="custom-control custom-switch">
-                                                    <input type="checkbox" class="custom-control-input" checked="true" name="checkboxes" id="opt-zoom">
-                                                    <label class="custom-control-label" for="opt-zoom"></label>
+                                                    <input type="checkbox" class="custom-control-input" checked="true" name="checkboxes" id="opt-zoomtools">
+                                                    <label class="custom-control-label" for="opt-zoomtools"></label>
                                                 </div>
                                             </div>                                            
                                         </li>
@@ -380,8 +380,8 @@
                                             <div class="list-flex">
                                                 <span><span i18n="tabs.app.opt_initialextent">Revenir à l'étendue initiale</span><span class="tooltip-info" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="Option permettant d'activer le bouton pour revenir à l'étendue intiale de l'application (initialextenttool)"><i class="ri-information-line"></i></span></span>                                           
                                                 <div class="custom-control custom-switch">
-                                                    <input type="checkbox" class="custom-control-input" name="checkboxes" id="opt-initialextent">
-                                                    <label class="custom-control-label" for="opt-initialextent"></label>
+                                                    <input type="checkbox" class="custom-control-input" name="checkboxes" id="opt-initialextenttool">
+                                                    <label class="custom-control-label" for="opt-initialextenttool"></label>
                                                 </div>
                                             </div>                                            
                                         </li>
@@ -472,7 +472,7 @@
                                                         <div class="col-md-6">
                                                             <div class="form-group">
                                                                 <label for="formCustomBaseThumb" class="form-label"><span i18n="tabs.app.bgcustom.base.thumb">Lien vers la vignette</span><span class="tooltip-info" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="Image permettant de visualiser l'aperçu du fond de plan"><i class="ri-information-line"></i></span></label>
-                                                                <input class="form-control" type="url" id="formCustomBaseThumb" i18n="tabs.app.bgcustom.base.thumb.ph" placeholder="https://kartenn.region-bretagne.fr/kartoviz/img/basemap/positron.png" required>
+                                                                <input class="form-control checkedurl" type="url" id="formCustomBaseThumb" i18n="tabs.app.bgcustom.base.thumb.ph" placeholder="https://kartenn.region-bretagne.fr/kartoviz/img/basemap/positron.png" required>
                                                             </div>
                                                         </div>
                                                         <div class="col-md-6">
@@ -484,7 +484,7 @@
                                                         <div class="col-md-6">
                                                             <div class="form-group">
                                                                 <label for="formCustomBaseUrl" class="form-label"><span i18n="tabs.app.bgcustom.base.url">URL</span><span class="tooltip-info" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="Lien vers le service web"><i class="ri-information-line"></i></span></label>
-                                                                <input class="form-control" type="url" id="formCustomBaseUrl" i18n="tabs.app.bgcustom.base.url.ph" placeholder="http://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" required>
+                                                                <input class="form-control checkedurl" type="url" id="formCustomBaseUrl" i18n="tabs.app.bgcustom.base.url.ph" placeholder="http://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png" required>
                                                             </div>
                                                         </div>   
                                                     </div>
@@ -492,7 +492,7 @@
                                                         <div class="col-md-6 vector-tms custom-bg-type">
                                                             <div class="form-group">
                                                                 <label for="formCustomBaseStyleUrl" class="form-label"><span i18n="tabs.app.bgcustom.base.styleUrl">Lien vers le fichier de style</span><span class="tooltip-info" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="Fichier JSON permettant de définir le style du fond de plan"><i class="ri-information-line"></i></span></label>
-                                                                <input class="form-control" type="url" id="formCustomBaseStyleUrl" i18n="tabs.app.bgcustom.base.styleUrl.ph" placeholder="https://wxs.ign.fr/static/vectorTiles/styles/ADMIN_EXPRESS/adminexpress.json" required>
+                                                                <input class="form-control checkedurl" type="url" id="formCustomBaseStyleUrl" i18n="tabs.app.bgcustom.base.styleUrl.ph" placeholder="https://wxs.ign.fr/static/vectorTiles/styles/ADMIN_EXPRESS/adminexpress.json" required>
                                                             </div>
                                                         </div>
                                                         <div class="col-md-6 wmts wms custom-bg-type">
@@ -612,7 +612,7 @@
                                                     <div class="row my-2 align-items-stretch">
                                                             <div class="col-md-6" id="opt-searchl-url" style="display: none;">
                                                                 <label for="opt-searchlocalities-url" i18n="tabs.app.search.address_search.url" class="form-label">URL</label>
-                                                                <input class="form-control" id="opt-searchlocalities-url" type="text" placeholder="Url du service">
+                                                                <input class="form-control checkedurl" id="opt-searchlocalities-url" type="text" placeholder="Url du service">
                                                             </div>
                                                             <div class="col-md-6" id="opt-searchl-attribution" style="display: none;">
                                                                 <label for="opt-searchlocalities-attribution" i18n="tabs.app.search.address_search.attribution" class="form-label">Attribution</label>
@@ -1111,7 +1111,7 @@
                                         <h6>Style de la donnée</h6>  
                                         <div class="form-group">
                                             <label for="frm-layertms-styleurl" i18n="modal.layer.new.param.tms.styleurl">Lien vers le fichier de style (JSON)</label>
-                                            <input type="text" class="form-control" id="frm-layertms-styleurl" placeholder="Url vers le fichier de style">
+                                            <input type="text" class="form-control checkedurl" id="frm-layertms-styleurl" placeholder="Url vers le fichier de style">
                                         </div>
                                         <div class="form-group">
                                             <label for="frm-layertms-stylename"><span i18n="modal.layer.new.param.tms.style">Nom du style</span><span class="tooltip-info" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="Le style correspond à la valeur indiquée en tant que première clé de la propriété « sources » du fichier de style au format JSON"><i class="ri-information-line"></i></label>
@@ -1255,7 +1255,7 @@
                                                 </div>
                                                 <div class="custom-control custom-switch">
                                                     <input type="checkbox" class="custom-control-input" id="frm-layer-exclusive">
-                                                    <label class="custom-control-label" for="frm-layer-exclusive" i18n="modal.layer.exclusive">Affichage exclusif de la donnée</label><span class="tooltip-info" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="En activant cette option, l'affichage de cette donnée masquera automatiquement toutes les autres données de la carte."><i class="ri-information-line"></i>
+                                                    <label class="custom-control-label" for="frm-layer-exclusive" i18n="modal.layer.exclusive">Affichage exclusif de la donnée</label><span class="tooltip-info" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="En activant cette option, l'affichage de cette donnée masquera automatiquement toutes les autres données de la carte ayant ce paramètre activé."><i class="ri-information-line"></i>
                                                 </div>
                                                 <div class="custom-control custom-switch">
                                                     <input type="checkbox" class="custom-control-input" id="frm-layer-showintoc">
@@ -1308,8 +1308,8 @@
                                             </div>
                                             <div class="form-group" id="group-legend-default">
                                                 <div class="custom-control custom-switch">
-                                                    <input type="checkbox" class="custom-control-input" id="frm-layer-legend-dynamic">
-                                                    <label class="custom-control-label" for="frm-layer-legend-dynamic" i18n="modal.layer.legend.dynamic">Adapter la légende selon les données visibles dans l'emprise de la carte</label>
+                                                    <input type="checkbox" class="custom-control-input" id="frm-layer-dynamiclegend">
+                                                    <label class="custom-control-label" for="frm-layer-dynamiclegend" i18n="modal.layer.legend.dynamic">Adapter la légende selon les données visibles dans l'emprise de la carte</label>
                                                 </div>
                                             </div>
                                             <div class="form-group mt-2 d-none" id="group-legend-custom">
@@ -1754,7 +1754,7 @@
                                         <div class="col-md-12 d-none">
                                             <div class="form-group">
                                                 <label class="control-label" for="newlayer-url" i18n="modal.layer.new.param.url">URL</label>
-                                                <input type="text" class="form-control" id="newlayer-url" placeholder="Lien vers la donnée">
+                                                <input type="text" class="form-control checkedurl" id="newlayer-url" placeholder="Lien vers la donnée">
                                             </div>                                    
                                         </div>
                                     </div>
@@ -1762,7 +1762,7 @@
                                         <div class="col-md-6 d-none vector-tms-type param-type">
                                             <div class="form-group">
                                                 <label class="control-label" for="newlayer-tms-styleurl" i18n="modal.layer.new.param.tms.styleurl">Lien vers le fichier de style (JSON)</label>
-                                                <input type="text" class="form-control" id="newlayer-tms-styleurl" placeholder="Lien vers la donnée">
+                                                <input type="text" class="form-control checkedurl" id="newlayer-tms-styleurl" placeholder="Lien vers la donnée">
                                             </div>                                    
                                         </div>
                                         <div class="col-md-6 d-none vector-tms-type param-type">

--- a/js/mviewerstudio.js
+++ b/js/mviewerstudio.js
@@ -599,11 +599,8 @@ var getConfig = () => {
     var olscompletion = "";
     var elasticsearch = "";
     // Url du studio
-    if ($('#opt-studio').prop('checked')=== true){
-        var studiourl = window.location.href;
-    } else {
-        var studiourl = 'false';
-    }
+    var studioUrl = $('#opt-studio').prop('checked') ? window.location.href || "" : "";
+   
     var application = ['<application',
         'title="'+$("#opt-title").val()+'"',
         'logo="'+$("#opt-logo").val()+'"',
@@ -621,7 +618,7 @@ var getConfig = () => {
         'measuretools="'+($('#opt-measuretools').prop('checked')=== true)+'"',
         'mouseposition="'+($('#opt-mouseposition').prop('checked')=== true)+'"',
         'geoloc="'+($('#opt-geoloc').prop('checked')=== true)+'"',
-        'studio="'+studiourl+'"',        
+        'studio="'+studioUrl+'"',        
         'togglealllayersfromtheme="'+($('#opt-togglealllayersfromtheme').prop('checked')=== true)+'"'];
 
     config.title = $("#opt-title").val();

--- a/js/mviewerstudio.js
+++ b/js/mviewerstudio.js
@@ -238,12 +238,12 @@ var newConfiguration = function (infos) {
     });
 
     // default checked state
-    ["opt-exportpng", "opt-zoom", "opt-geoloc", "opt-mouseposition", "opt-studio", "opt-measuretools", "opt-initialextent", "theme-edit-collapsed", "opt-mini", "opt-showhelp", "opt-coordinates",
+    ["opt-exportpng", "opt-zoomtools", "opt-geoloc", "opt-mouseposition", "opt-studio", "opt-measuretools", "opt-initialextenttool", "theme-edit-collapsed", "opt-mini", "opt-showhelp", "opt-coordinates",
         "opt-togglealllayersfromtheme", "SwitchAdressSearch", "SwitchCustomBackground", "SwitchAdvanced"
     ].forEach(id => {
         document.querySelector(`#${ id }`).checked = false;
     });
-    ["opt-zoom", "opt-measuretools"].forEach(id => {
+    ["opt-zoomtools", "opt-measuretools", "opt-initialextenttool"].forEach(id => {
         document.querySelector(`#${ id }`).checked = true;
     });
     
@@ -598,6 +598,12 @@ var getConfig = () => {
     var savedProxy = "";
     var olscompletion = "";
     var elasticsearch = "";
+    // Url du studio
+    if ($('#opt-studio').prop('checked')=== true){
+        var studiourl = window.location.href;
+    } else {
+        var studiourl = 'false';
+    }
     var application = ['<application',
         'title="'+$("#opt-title").val()+'"',
         'logo="'+$("#opt-logo").val()+'"',
@@ -607,15 +613,15 @@ var getConfig = () => {
         'iconhelp="'+$("#opt-iconhelp").val()+'"',
         'home="'+$("#opt-home").val()+'"',
         'style="'+$("#opt-style").val()+'"',
-        'zoomtools="'+($('#opt-zoom').prop('checked')=== true)+'"',
-        'initialextenttool="'+($('#opt-initialextent').prop('checked')=== true)+'"',
+        'zoomtools="'+($('#opt-zoomtools').prop('checked')=== true)+'"',
+        'initialextenttool="'+($('#opt-initialextenttool').prop('checked')=== true)+'"',
         'exportpng="'+($('#opt-exportpng').prop('checked')=== true)+'"',        
         'showhelp="'+($('#opt-showhelp').prop('checked')=== true)+'"',
         'coordinates="'+($('#opt-coordinates').prop('checked')=== true)+'"',
         'measuretools="'+($('#opt-measuretools').prop('checked')=== true)+'"',
         'mouseposition="'+($('#opt-mouseposition').prop('checked')=== true)+'"',
         'geoloc="'+($('#opt-geoloc').prop('checked')=== true)+'"',
-        'studio="'+($('#opt-studio').prop('checked')=== true)+'"',        
+        'studio="'+studiourl+'"',        
         'togglealllayersfromtheme="'+($('#opt-togglealllayersfromtheme').prop('checked')=== true)+'"'];
 
     config.title = $("#opt-title").val();

--- a/js/mviewerstudio.js
+++ b/js/mviewerstudio.js
@@ -21,7 +21,7 @@ $(document).ready(function(){
             //Mviewer Studio version
             console.log("MviewerStudio version " + VERSION);
             console.groupCollapsed("init app from config");
-            _conf = data.app_conf;
+            _conf = data.app_conf;          
             if (_conf.proxy === undefined) {
                 _conf.proxy = "../proxy/?url=";
             }
@@ -239,12 +239,12 @@ var newConfiguration = function (infos) {
     });
 
     // default checked state
-    ["opt-exportpng", "opt-zoom", "opt-geoloc", "opt-mouseposition", "opt-studio", "opt-measuretools", "opt-initialextent", "theme-edit-collapsed", "opt-mini", "opt-showhelp", "opt-coordinates",
+    ["opt-exportpng", "opt-zoomtools", "opt-geoloc", "opt-mouseposition", "opt-studio", "opt-measuretools", "opt-initialextenttool", "theme-edit-collapsed", "opt-mini", "opt-showhelp", "opt-coordinates",
         "opt-togglealllayersfromtheme", "SwitchAdressSearch", "SwitchCustomBackground", "SwitchAdvanced"
     ].forEach(id => {
         document.querySelector(`#${ id }`).checked = false;
     });
-    ["opt-zoom", "opt-measuretools"].forEach(id => {
+    ["opt-zoomtools", "opt-measuretools", "opt-initialextenttool"].forEach(id => {
         document.querySelector(`#${ id }`).checked = true;
     });
     
@@ -599,6 +599,12 @@ var getConfig = () => {
     var savedProxy = "";
     var olscompletion = "";
     var elasticsearch = "";
+    // Url du studio
+    if ($('#opt-studio').prop('checked')=== true){
+        var studiourl = window.location.href;
+    } else {
+        var studiourl = 'false';
+    }
     var application = ['<application',
         'title="'+$("#opt-title").val()+'"',
         'logo="'+$("#opt-logo").val()+'"',
@@ -608,15 +614,15 @@ var getConfig = () => {
         'iconhelp="'+$("#opt-iconhelp").val()+'"',
         'home="'+$("#opt-home").val()+'"',
         'style="'+$("#opt-style").val()+'"',
-        'zoomtools="'+($('#opt-zoom').prop('checked')=== true)+'"',
-        'initialextenttool="'+($('#opt-initialextent').prop('checked')=== true)+'"',
+        'zoomtools="'+($('#opt-zoomtools').prop('checked')=== true)+'"',
+        'initialextenttool="'+($('#opt-initialextenttool').prop('checked')=== true)+'"',
         'exportpng="'+($('#opt-exportpng').prop('checked')=== true)+'"',        
         'showhelp="'+($('#opt-showhelp').prop('checked')=== true)+'"',
         'coordinates="'+($('#opt-coordinates').prop('checked')=== true)+'"',
         'measuretools="'+($('#opt-measuretools').prop('checked')=== true)+'"',
         'mouseposition="'+($('#opt-mouseposition').prop('checked')=== true)+'"',
         'geoloc="'+($('#opt-geoloc').prop('checked')=== true)+'"',
-        'studio="'+($('#opt-studio').prop('checked')=== true)+'"',        
+        'studio="'+studiourl+'"',        
         'togglealllayersfromtheme="'+($('#opt-togglealllayersfromtheme').prop('checked')=== true)+'"'];
 
     config.title = $("#opt-title").val();

--- a/lib/mv.js
+++ b/lib/mv.js
@@ -582,7 +582,7 @@ var mv = (function () {
                 $("#frm-scalemax").val(layer.scalemax);
                 $("#frm-filter").val(layer.filter);
                 $("#frm-layer-styletitle").val(layer.styletitle || "");
-                $("#frm-layer-dynamiclegend").val(layer.dynamiclegend || "");
+                $("#frm-layer-dynamiclegend").prop("checked", layer.dynamiclegend);
                 if (layer.attributefilter) {
                     $("#frm-attributelabel").val(layer.attributelabel);
                     layer.attributevalues.split(",").forEach(function (value, id) {
@@ -1097,23 +1097,17 @@ var mv = (function () {
         },
 
         checkURL: function (e) {
-            var ctrl = e.currentTarget;
-            var url = mv.ajaxURL(ctrl.value, e);
-            console.log(url)
-            $.ajax({
-                context: this,
-                type: "HEAD",
-                async: true,
-                url: url,
-                success: function(data, status, xhr, ctrl) {
-                    if (xhr.status === 200) {
-                        $(this).css("color", "#009688");
-                    }
-                },
-                error: function(data, status, xhr) {
-                    $(this).css("color", "#ff9085");
-                }
-            });
+            var ctrl = e.currentTarget;          
+            var url = ctrl.value;
+            var expression = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi;
+            var regexp = new RegExp(expression);
+            if (regexp.test(url)){
+                $(this).css("color", "#009688");
+            }
+            else{
+                $(this).css("color", "#ff9085");
+            }               
+            return regexp.test(url);
         },
 
         createDublinCore(data) {
@@ -1242,8 +1236,7 @@ var mv = (function () {
             }
             if (searchparameters && searchparameters.attr("features") ) {
                 $("#opt-searchfeatures").prop("checked", (searchparameters.attr("features") === "true"));
-            }
-
+            }     
             [proxy].forEach(function(param,id) {
                 // this parameters are not yet supported but must be saved for later
                 if (param.length>0) {
@@ -1271,16 +1264,19 @@ var mv = (function () {
                     savedParameters.application.push(parameter);
                 }
             });
-            ["title", "logo", "help", "style"].forEach(function(value,id) {
+            ["title", "logo", "help", "style", "home", "favicon", "icon-help", "studio"].forEach(function(value,id) {
                 if (application.attr(value)) {
                     $("#opt-" + value).val(application.attr(value)).trigger("change");
                 }
                 if (value === "style") {
                     updateTheme($("#opt-" + value)[0]);
                 }
+                if (value === "studio" && application.attr(value) != 'false') {
+                    $("#opt-studio").prop("checked", true);
+                }
             });
 
-            ["exportpng", "measuretools", "showhelp", "coordinates", 
+            ["exportpng","zoomtools", "measuretools", "showhelp", "coordinates",  "mouseposition", "geoloc", "initialextenttool",
                 "togglealllayersfromtheme"].forEach(function(value,id) {
                 if (application.attr(value) && application.attr(value) === "true") {
                     $("#opt-" + value).prop("checked", true);


### PR DESCRIPTION
Modifications réalisées : 
- Librairie font awesome 5.6.3 vers 5.13 (iso avec le mviewer)
- Revenir à l'étendue initiale doit être coché par défaut
- Adapter la légende selon le zoom de la carte n'est pas conservé à l'enregistrement dans le XML
- Libellé info "Affichage exclusif de la donnée". Il faut préciser que ça concerne toutes les données de la carte qui ont ce même paramétrage.
- Validation des urls : emplacement de la requête ajax par un test selon une expression régulière regex + ajout de la class .checkedurl sur les inputs de lien manquants
- Correction du lien pour l'option studio
- Harmonisation des noms d'options vis à vis des noms utilisés dans la config 